### PR TITLE
[bitnami/keycloak] Fix reference to external db secret password key

### DIFF
--- a/bitnami/keycloak/templates/secret-external-db.yaml
+++ b/bitnami/keycloak/templates/secret-external-db.yaml
@@ -13,5 +13,5 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  db-password: {{ include "common.secrets.passwords.manage" (dict "secret" (printf "%s-externaldb" .Release.Name) "key" "password" "length" 10 "providedValues" (list "externalDatabase.password") "context" $) }}
+  db-password: {{ include "common.secrets.passwords.manage" (dict "secret" (printf "%s-externaldb" .Release.Name) "key" "db-password" "length" 10 "providedValues" (list "externalDatabase.password") "context" $) }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fixes the following error on deployment:
```
STDERR:
  Error: UPGRADE FAILED: execution error at (keycloak/templates/secret-external-db.yaml:16:18):
  PASSWORDS ERROR: The secret "keycloak-dev-externaldb" does not contain the key "password"
```

### Additional information

How to reproduce:

1. install the Keycloak chart v11.0.0 for the first time - it works
2. re-install the same chart: it fails with the error above because this time the secret exists but the key name is wrong.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)